### PR TITLE
First round of feedback for idiomatic Rust review

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,5 @@ rmpv = "1.0.0"
 safetensors = "0.3.0"
 serde = { version = "1.0.156", features = ["derive"] }
 serde_json = "1.0.94"
+snafu = { version = "0.7.4", features = ["rust_1_61", "backtraces-impl-std"] }
  

--- a/src/dicom_json.rs
+++ b/src/dicom_json.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+use crate::ir_to_dimble::VR;
+
 pub type DicomJsonData = HashMap<String, DicomField>;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
@@ -24,8 +26,34 @@ pub struct DicomField {
     #[serde(rename = "Value")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<Vec<DicomValue>>,
-    pub vr: String,
+    #[serde(with = "vr_serialization")]
+    pub vr: VR,
     #[serde(rename = "InlineBinary")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub inline_binary: Option<String>,
+}
+
+mod vr_serialization {
+    use serde::{
+        de::Error as _, ser::Error as _, Deserialize, Deserializer, Serialize, Serializer,
+    };
+    use std::borrow::Cow;
+
+    use super::VR;
+
+    pub fn serialize<S>(value: &VR, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let value = std::str::from_utf8(value).map_err(S::Error::custom)?;
+        value.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<VR, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = <Cow<'de, str>>::deserialize(deserializer)?;
+        value.as_bytes().try_into().map_err(D::Error::custom)
+    }
 }

--- a/src/dimble_to_ir.rs
+++ b/src/dimble_to_ir.rs
@@ -47,11 +47,7 @@ fn headerfield_and_bytes_to_dicom_fields(
                             // Pixel Data
                             "TODO encode pixel data correctly".to_string()
                         }
-                        _ => {
-                            let mut cursor = field_bytes;
-                            let v = decode::read_value(&mut cursor).unwrap();
-                            v.as_str().unwrap().to_string()
-                        }
+                        _ => rmp_serde::decode::from_slice(field_bytes).unwrap(),
                     };
 
                     DicomField {
@@ -61,12 +57,7 @@ fn headerfield_and_bytes_to_dicom_fields(
                     }
                 }
                 b"PN" => {
-                    let mut cursor = field_bytes;
-                    let v = decode::read_value(&mut cursor).unwrap();
-                    let name = match v {
-                        Value::String(s) => s.into_str().unwrap(),
-                        _ => panic!("expected string"),
-                    };
+                    let name = rmp_serde::decode::from_slice(field_bytes).unwrap();
                     let a = DicomValue::Alphabetic(Alphabetic { alphabetic: name });
                     DicomField {
                         value: Some(vec![a]),

--- a/src/dimble_to_ir.rs
+++ b/src/dimble_to_ir.rs
@@ -81,18 +81,12 @@ fn headerfield_and_bytes_to_dicom_fields(
                                     }
                                     Value::Integer(i) => values.push(integer_to_dicom_value(&i)),
                                     Value::F64(f) => values.push(DicomValue::Float(f)),
-                                    _ => {
-                                        println!("unexpected value type: {:?}", v);
-                                        panic!("unexpected value type")
-                                    }
+                                    _ => panic!("unexpected value type: {v:?}"),
                                 };
                             }
                             values
                         }
-                        _ => {
-                            println!("unexpected value type: {:?}", v);
-                            panic!("unexpected value type")
-                        }
+                        _ => panic!("unexpected value type: {v:?}"),
                     };
                     DicomField {
                         value: Some(value),

--- a/src/dimble_to_ir.rs
+++ b/src/dimble_to_ir.rs
@@ -40,7 +40,7 @@ fn headerfield_and_bytes_to_dicom_fields(
             let field_pos: usize = (*field_pos as usize) + 8;
             let field_length = *field_length as usize;
             let field_bytes = &dimble_buffer[field_pos..field_pos + field_length];
-            let dicom_field: DicomField = match vr {
+            match vr {
                 b"OB" | b"OW" => {
                     let inline_binary: String = match tag {
                         "7FE00010" => {
@@ -89,8 +89,7 @@ fn headerfield_and_bytes_to_dicom_fields(
                         inline_binary: None,
                     }
                 }
-            };
-            dicom_field
+            }
         }
     }
 }

--- a/src/dimble_to_ir.rs
+++ b/src/dimble_to_ir.rs
@@ -72,20 +72,15 @@ fn headerfield_and_bytes_to_dicom_fields(
                         Value::String(s) => vec![DicomValue::String(s.into_str().unwrap())],
                         Value::Integer(i) => vec![integer_to_dicom_value(&i)],
                         Value::F64(f) => vec![DicomValue::Float(f)],
-                        Value::Array(a) => {
-                            let mut values = Vec::new();
-                            for v in a {
-                                match v {
-                                    Value::String(s) => {
-                                        values.push(DicomValue::String(s.into_str().unwrap()))
-                                    }
-                                    Value::Integer(i) => values.push(integer_to_dicom_value(&i)),
-                                    Value::F64(f) => values.push(DicomValue::Float(f)),
-                                    _ => panic!("unexpected value type: {v:?}"),
-                                };
-                            }
-                            values
-                        }
+                        Value::Array(a) => a
+                            .into_iter()
+                            .map(|v| match v {
+                                Value::String(s) => DicomValue::String(s.into_str().unwrap()),
+                                Value::Integer(i) => integer_to_dicom_value(&i),
+                                Value::F64(f) => DicomValue::Float(f),
+                                _ => panic!("unexpected value type: {v:?}"),
+                            })
+                            .collect(),
                         _ => panic!("unexpected value type: {v:?}"),
                     };
                     DicomField {

--- a/src/dimble_to_ir.rs
+++ b/src/dimble_to_ir.rs
@@ -3,7 +3,6 @@ use crate::ir_to_dimble::{HeaderField, HeaderFieldMap};
 use memmap2::MmapOptions;
 use rmpv::{decode, Value};
 use std::fs;
-use std::io::Cursor;
 
 fn headerfield_and_bytes_to_dicom_fields(
     tag: &str,
@@ -53,7 +52,7 @@ fn headerfield_and_bytes_to_dicom_fields(
                             "TODO encode pixel data correctly".to_string()
                         }
                         _ => {
-                            let mut cursor = Cursor::new(field_bytes);
+                            let mut cursor = field_bytes;
                             let v = decode::read_value(&mut cursor).unwrap();
                             v.as_str().unwrap().to_string()
                         }
@@ -66,7 +65,7 @@ fn headerfield_and_bytes_to_dicom_fields(
                     }
                 }
                 "PN" => {
-                    let mut cursor = Cursor::new(field_bytes);
+                    let mut cursor = field_bytes;
                     let v = decode::read_value(&mut cursor).unwrap();
                     let name = match v {
                         Value::String(s) => s.into_str().unwrap(),
@@ -80,7 +79,7 @@ fn headerfield_and_bytes_to_dicom_fields(
                     }
                 }
                 _ => {
-                    let mut cursor = Cursor::new(field_bytes);
+                    let mut cursor = field_bytes;
                     let v = decode::read_value(&mut cursor).unwrap();
                     let value: Vec<DicomValue> = match v {
                         Value::String(s) => vec![DicomValue::String(s.into_str().unwrap())],

--- a/src/dimble_to_ir.rs
+++ b/src/dimble_to_ir.rs
@@ -19,9 +19,9 @@ fn headerfield_and_bytes_to_dicom_fields(
             let seq_fields = sqs
                 .iter()
                 .map(|sq| {
-                    let mut sq_data: DicomJsonData = DicomJsonData::new();
+                    let mut sq_data = DicomJsonData::new();
                     for (tag, header_field) in sq.iter() {
-                        let field: DicomField =
+                        let field =
                             headerfield_and_bytes_to_dicom_fields(tag, header_field, dimble_buffer);
                         sq_data.insert(tag.to_string(), field);
                     }
@@ -37,12 +37,12 @@ fn headerfield_and_bytes_to_dicom_fields(
         }
         HeaderField::Deffered(field_pos, field_length, vr) => {
             // inline_binary VRs are OB and OW. TODO support the other inline binary VRs
-            let field_pos: usize = (*field_pos as usize) + 8;
+            let field_pos = (*field_pos as usize) + 8;
             let field_length = *field_length as usize;
             let field_bytes = &dimble_buffer[field_pos..field_pos + field_length];
             match vr {
                 b"OB" | b"OW" => {
-                    let inline_binary: String = match tag {
+                    let inline_binary = match tag {
                         "7FE00010" => {
                             // Pixel Data
                             "TODO encode pixel data correctly".to_string()
@@ -68,7 +68,7 @@ fn headerfield_and_bytes_to_dicom_fields(
                 _ => {
                     let mut cursor = field_bytes;
                     let v = decode::read_value(&mut cursor).unwrap();
-                    let value: Vec<DicomValue> = match v {
+                    let value: Vec<_> = match v {
                         Value::String(s) => vec![DicomValue::String(s.into_str().unwrap())],
                         Value::Integer(i) => vec![integer_to_dicom_value(&i)],
                         Value::F64(f) => vec![DicomValue::Float(f)],
@@ -113,7 +113,7 @@ pub fn dimble_to_dicom_json(dimble_path: &str, json_path: &str) {
     let mut json_dicom = DicomJsonData::new();
 
     for (tag, header_field) in header.iter() {
-        let field: DicomField =
+        let field =
             headerfield_and_bytes_to_dicom_fields(tag, header_field, &dimble_buffer[header_len..]);
         json_dicom.insert(tag.to_string(), field);
     }
@@ -124,7 +124,7 @@ pub fn dimble_to_dicom_json(dimble_path: &str, json_path: &str) {
 
 fn deserialise_header(buffer: &[u8]) -> (HeaderFieldMap, usize) {
     let header_len = u64::from_le_bytes(buffer[0..8].try_into().unwrap()) as usize;
-    let header: HeaderFieldMap =
+    let header =
         rmp_serde::from_slice(&buffer[8..8 + header_len]).expect("failed to deserialise header");
     (header, header_len)
 }

--- a/src/ir_to_dimble.rs
+++ b/src/ir_to_dimble.rs
@@ -211,9 +211,7 @@ pub fn dicom_json_to_dimble(
 }
 
 fn deserialise_ir(data: impl Read) -> DicomJsonData {
-    let dicom_json: HashMap<String, DicomField> =
-        serde_json::from_reader(data).expect("Failed to parse JSON");
-    dicom_json
+    serde_json::from_reader(data).expect("Failed to parse JSON")
 }
 
 #[cfg(test)]

--- a/src/ir_to_dimble.rs
+++ b/src/ir_to_dimble.rs
@@ -217,7 +217,6 @@ fn deserialise_ir(data: impl Read) -> DicomJsonData {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Cursor;
 
     #[test]
     fn test_ir_deserialisation() {
@@ -321,7 +320,7 @@ mod tests {
         let file_bytes = fs::read(dimble_path).unwrap();
         assert_eq!(file_bytes.last().unwrap(), &0x42);
         let header_len = u64::from_le_bytes(file_bytes[0..8].try_into().unwrap()) as usize;
-        let mut cursor = Cursor::new(&file_bytes[8..8 + header_len]);
+        let mut cursor = &file_bytes[8..8 + header_len];
 
         let _decoded = rmpv::decode::read_value(&mut cursor).unwrap();
     }

--- a/src/ir_to_dimble.rs
+++ b/src/ir_to_dimble.rs
@@ -165,7 +165,7 @@ fn prepare_dicom_fields_for_serialisation(
     dicom_json_data: DicomJsonData,
     pixel_array_safetensors_path: Option<&str>,
 ) -> InnerResult<(HeaderFieldMap, Vec<u8>)> {
-    let mut data_bytes: Vec<u8> = Vec::new();
+    let mut data_bytes = Vec::new();
 
     let header_fields = prepare_dimble_fields(
         &dicom_json_data,

--- a/src/ir_to_dimble.rs
+++ b/src/ir_to_dimble.rs
@@ -33,10 +33,10 @@ fn get_file_bytes(safetensors_path: &str) -> Vec<u8> {
 
 fn dicom_values_to_vec(tag: &str, dicom_values: &[DicomValue]) -> Option<Vec<u8>> {
     let field_bytes = match dicom_values {
-        [DicomValue::String(s)] => to_vec(&s).unwrap(),
-        [DicomValue::Integer(u)] => to_vec(&u).unwrap(),
-        [DicomValue::Float(u)] => to_vec(&u).unwrap(),
-        [DicomValue::Alphabetic(u)] => to_vec(&u.alphabetic).unwrap(),
+        [DicomValue::String(s)] => to_vec(&s),
+        [DicomValue::Integer(u)] => to_vec(&u),
+        [DicomValue::Float(u)] => to_vec(&u),
+        [DicomValue::Alphabetic(u)] => to_vec(&u.alphabetic),
         many => match many
             .first()
             .expect("This should definitely have a first element")
@@ -49,8 +49,7 @@ fn dicom_values_to_vec(tag: &str, dicom_values: &[DicomValue]) -> Option<Vec<u8>
                         _ => panic!("{tag} expected only strings"),
                     })
                     .collect::<Vec<String>>(),
-            )
-            .unwrap(),
+            ),
             DicomValue::Integer(_) => to_vec(
                 &many
                     .iter()
@@ -59,8 +58,7 @@ fn dicom_values_to_vec(tag: &str, dicom_values: &[DicomValue]) -> Option<Vec<u8>
                         _ => panic!("{tag} expected only ints"),
                     })
                     .collect::<Vec<i64>>(),
-            )
-            .unwrap(),
+            ),
             DicomValue::Float(_) => to_vec(
                 &many
                     .iter()
@@ -69,8 +67,7 @@ fn dicom_values_to_vec(tag: &str, dicom_values: &[DicomValue]) -> Option<Vec<u8>
                         _ => panic!("{tag} expected only floats"),
                     })
                     .collect::<Vec<f64>>(),
-            )
-            .unwrap(),
+            ),
             DicomValue::SeqField(_) => {
                 // TODO: handle sequences of sequences properly
                 return None;
@@ -78,6 +75,7 @@ fn dicom_values_to_vec(tag: &str, dicom_values: &[DicomValue]) -> Option<Vec<u8>
             other => panic!("{tag} unexpected value type {:?}", other),
         },
     };
+    let field_bytes = field_bytes.unwrap();
     Some(field_bytes)
 }
 

--- a/src/ir_to_dimble.rs
+++ b/src/ir_to_dimble.rs
@@ -27,10 +27,7 @@ fn extend_and_make_field(data_bytes: &mut Vec<u8>, field_bytes: &[u8], vr: VR) -
 pub type HeaderFieldMap = HashMap<String, HeaderField>;
 
 fn get_file_bytes(safetensors_path: &str) -> Vec<u8> {
-    let mut f = fs::File::open(safetensors_path).unwrap();
-    let mut buffer = Vec::new();
-    f.read_to_end(&mut buffer).unwrap();
-    buffer
+    fs::read(safetensors_path).unwrap()
 }
 
 fn dicom_values_to_vec(tag: &str, dicom_values: &[DicomValue]) -> Option<Vec<u8>> {

--- a/src/ir_to_dimble.rs
+++ b/src/ir_to_dimble.rs
@@ -1,12 +1,12 @@
 use rmp_serde::{to_vec, Serializer};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use std::fs;
-use std::io::{BufReader, Write};
+use std::{
+    collections::HashMap,
+    fs,
+    io::{prelude::*, BufReader, SeekFrom, Write},
+};
 
 use crate::dicom_json::*;
-use std::io::prelude::*;
-use std::io::SeekFrom;
 
 pub(crate) type VR = [u8; 2]; // TODO use newtype pattern?
 

--- a/src/ir_to_dimble.rs
+++ b/src/ir_to_dimble.rs
@@ -85,13 +85,15 @@ fn prepare_dimble_fields(
     data_bytes: &mut Vec<u8>,
     pixel_array_safetensors_path: Option<&str>,
 ) -> HeaderFieldMap {
-    let mut header_field_map: HeaderFieldMap = HeaderFieldMap::new();
-    for (tag, dicom_field) in dicom_fields.iter() {
-        let header_field: HeaderField =
-            prepare_dimble_field(tag, dicom_field, data_bytes, pixel_array_safetensors_path);
-        header_field_map.insert(tag.to_owned(), header_field);
-    }
-    header_field_map
+    dicom_fields
+        .iter()
+        .map(|(tag, dicom_field)| {
+            (
+                tag.to_owned(),
+                prepare_dimble_field(tag, dicom_field, data_bytes, pixel_array_safetensors_path),
+            )
+        })
+        .collect()
 }
 
 fn prepare_dimble_field(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,11 +310,7 @@ fn header_fields_and_buffer_to_pydict(
                     .set_item(field, py.None())
                     .expect("inserting should work");
             }
-            None => {
-                println!("field not found: {}", field);
-                println!("header: {:?}", header);
-                panic!("field not found: {}", field);
-            }
+            None => panic!("field {field} not found for header {header:?}"),
         }
     }
     Ok(dataset.into_py(py))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::File;
 
+use crate::ir_to_dimble::HEADER_LENGTH_LENGTH;
+
 static TORCH_MODULE: GILOnceCell<Py<PyModule>> = GILOnceCell::new();
 #[pyfunction]
 fn dicom_json_to_dimble(
@@ -299,12 +301,12 @@ fn deserialise_dimble_header(buffer: &[u8]) -> Result<(HeaderFieldMap, usize), D
     // TODO better error handling, this is a mess
 
     assert!(
-        buffer.len() >= 8,
-        "file should have 8 byte header, is only {}",
+        buffer.len() >= usize::from(HEADER_LENGTH_LENGTH),
+        "file should have {HEADER_LENGTH_LENGTH} byte header, is only {}",
         buffer.len(),
     );
     // TODO: `split_array_ref` when stable
-    let (header_len, buffer) = buffer.split_at(8);
+    let (header_len, buffer) = buffer.split_at(HEADER_LENGTH_LENGTH.into());
     let header_len = u64::from_le_bytes(header_len.try_into().unwrap()) as usize;
 
     let header = &buffer[..header_len];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,10 +253,7 @@ fn header_fields_and_buffer_to_pydict(
     slices: &Option<Vec<&PySlice>>,
 ) -> PyResult<PyObject> {
     let dataset = PyDict::new(py);
-    let fields = match fields {
-        Some(fields) => fields,
-        None => header.keys().map(|k| k.as_str()).collect(),
-    };
+    let fields = fields.unwrap_or_else(|| header.keys().map(|k| k.as_str()).collect());
     for field in fields {
         match header.get(field) {
             Some(HeaderField::Deffered(field_pos, field_length, _vr)) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,8 +217,8 @@ fn value_to_py(py: Python, value: Value) -> PyObject {
         Value::String(s) => s.into_str().into_py(py),
         Value::F64(f) => f.into_py(py),
         Value::Integer(i) => {
-            if i.is_i64() {
-                i.as_i64().unwrap().into_py(py)
+            if let Some(v) = i.as_i64() {
+                v.into_py(py)
             } else {
                 i.as_u64().unwrap().into_py(py)
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,6 @@ use rmpv::Value;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::File;
-use std::io::Cursor;
 
 static TORCH_MODULE: GILOnceCell<Py<PyModule>> = GILOnceCell::new();
 #[pyfunction]
@@ -237,7 +236,7 @@ fn value_to_py(py: Python, value: Value) -> PyObject {
 
 fn get_field(py: Python, buffer: &[u8], field_pos: usize, field_length: usize) -> Py<PyAny> {
     let field_bytes = &buffer[field_pos..field_pos + field_length];
-    let mut cursor = Cursor::new(field_bytes);
+    let mut cursor = field_bytes;
     let field_value = read_value(&mut cursor).expect("should be valid messagepack"); // TODO better error handling
     value_to_py(py, field_value)
 }


### PR DESCRIPTION
I tried to add commit messages when things might not be obvious, but feel free to ask questions about anything. Also, not all of the commits need to be accepted — if some are useful we can keep those and toss the rest.

Here are some other non-direct-code thoughts I had...

- I expect people looking at the Rust code are going to look for some
  hot-button issues.

  - Usage of `unsafe`. The Rust community generally dislikes `unsafe`
    being used for "frivolous" purposes. Every `unsafe` block should
    be annotated with a `SAFETY` comment that explains why that
    specific usage is safe. This is helpful to show what aspects you
    have thought for now and in the future when you revisit the
    code. Any `unsafe fn` should have a `# Safety` section in its
    documentation explaining what the caller needs to do to uphold the
    safety invariants.

  - Documentation for public API functions. You don't have much here /
    the public API is really from Python. It may be worth running
    `cargo doc --open` and checking out the docs as they are.

  - Relatedly, how your API is organized. There's a single public
    function and a handful of types, so there's not really many
    concerns for organization at the moment.

  - Normal project health signals — user-facing documentation,
    examples, tests, CI/CD, responsiveness to issues & pull requests,
    number of issues & pull requests.

- `mmap` is contentious. As best as I've ever figured out, it's not
  actually safe to the letter of the law in Rust. That's because it
  presents an API where data is immutable but can actually be mutated
  from [outside of the Rust process][mmap]. It would probably be good
  to have some hard numbers for "when we used `mmap`, the time went
  from X to Y" to show that this isn't a frivolous usage of unsafe.

- Numeric casts with `as` are usually pretty suspicious. These can
  silently transform your data from something meaningful to something
  not. When possible, usage of `Into` or `TryInto` is recommended.

- The code appears to cast freely between `u64` and `usize`, which
  suggests that it really only works on 64-bit machines. Ideally, that
  would be enforced at compile time to prevent anyone from
  accidentally running this on 32-bit machines. Otherwise, the code
  should guard against cases where a `u64` cannot fit in a `usize`.

- The duplication of `to_vec` in the match arms of
  `dicom_values_to_vec` is ultimately required because each call is
  being monomorphized for the specific type passed in. Even though the
  source code is the same, the generated code differs for each
  concrete type.

- `7FE00010` appears to be a magic value; ideally this should be a
  constant with a useful name. There are a handful of similar values
  floating around as well (`OB`, `PN`, etc.).

- From a non-AI, non-ML only-Rust perspective, I would be curious why
  there's not a separate Rust-only library, as opposed to the current
  one so tightly bound to Python. We love our pure Rust cores with
  wrapper layers for other languages. These aren't free as usually
  there's a bit more type shuffling needed in those adapter layers.

- Using files as a data transfer mechanism between the Python and the
  Rust is a bit surprising. Perhaps this is mostly done for the
  ability to use mmap or development velocity, but I had expected to
  see sending giant blobs of bytes around.

[mmap]: https://docs.rs/memmap2/latest/memmap2/struct.Mmap.html#safety